### PR TITLE
Rg invalid args error

### DIFF
--- a/crates/core/main.rs
+++ b/crates/core/main.rs
@@ -39,7 +39,11 @@ mod search;
 #[global_allocator]
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
-/// Then, as it was, then again it will be.
+/// Exit codes:
+///   0 - At least one match was found.
+///   1 - No matches were found.
+///   2 - Invalid arguments (e.g., bad pattern, unrecognized flag).
+///   3 - One or more non-fatal runtime errors occurred (e.g., file not found).
 fn main() -> ExitCode {
     match run(flags::parse()) {
         Ok(code) => code,
@@ -97,7 +101,11 @@ fn run(result: crate::flags::ParseResult<HiArgs>) -> anyhow::Result<ExitCode> {
     Ok(if matched && (args.quiet() || !messages::errored()) {
         ExitCode::from(0)
     } else if messages::errored() {
-        ExitCode::from(2)
+        // Exit code 3 indicates a non-fatal runtime error occurred during
+        // search (e.g., a file could not be read). This is distinct from
+        // exit code 2, which indicates a fatal error caused by invalid
+        // arguments (e.g., an invalid pattern or unrecognized flag).
+        ExitCode::from(3)
     } else {
         ExitCode::from(1)
     })

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -814,9 +814,9 @@ rgtest!(r1159_exit_status, |dir: Dir, _: TestCommand| {
     let mut cmd = dir.command();
     cmd.arg("-q").arg("test").assert_exit_code(0);
 
-    // search with a match and an error gets 2 exit status.
+    // search with a match and a runtime error gets 3 exit status.
     let mut cmd = dir.command();
-    cmd.arg("test").arg("no-file").assert_exit_code(2);
+    cmd.arg("test").arg("no-file").assert_exit_code(3);
 
     // search with a match in --quiet mode and an error gets 0 exit status.
     let mut cmd = dir.command();
@@ -830,13 +830,14 @@ rgtest!(r1159_exit_status, |dir: Dir, _: TestCommand| {
     let mut cmd = dir.command();
     cmd.arg("-q").arg("nada").assert_exit_code(1);
 
-    // search with no match and an error gets 2 exit status.
+    // search with no match and a runtime error gets 3 exit status.
     let mut cmd = dir.command();
-    cmd.arg("nada").arg("no-file").assert_exit_code(2);
+    cmd.arg("nada").arg("no-file").assert_exit_code(3);
 
-    // search with no match in --quiet mode and an error gets 2 exit status.
+    // search with no match in --quiet mode and a runtime error gets 3 exit
+    // status.
     let mut cmd = dir.command();
-    cmd.arg("-q").arg("nada").arg("foo").arg("no-file").assert_exit_code(2);
+    cmd.arg("-q").arg("nada").arg("foo").arg("no-file").assert_exit_code(3);
 });
 
 // See: https://github.com/BurntSushi/ripgrep/issues/1163


### PR DESCRIPTION
Change exit codes to differentiate between invalid arguments (2) and non-fatal runtime errors (3), classifying the `\n` literal regex error as an invalid argument.

Previously, ripgrep used exit code 2 for all errors, making it impossible to distinguish between invalid arguments and runtime errors. This PR introduces exit code 3 for non-fatal runtime errors (e.g., file not found) while keeping exit code 2 for fatal errors (e.g., invalid regex, unrecognized flags). The `\n` literal regex error is a fatal error (invalid argument) and now correctly returns exit code 2.

---
[Slack Thread](https://anysphere.slack.com/archives/D0901RLS10R/p1771285984916019?thread_ts=1771285984.916019&cid=D0901RLS10R)

<p><a href="https://cursor.com/background-agent?bcId=bc-6782aa44-d1aa-5d20-aacb-312d006a4701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6782aa44-d1aa-5d20-aacb-312d006a4701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

