### PR TITLE
Add AGENTS.md for Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a Cursor fork of ripgrep (`rg`), a Rust CLI tool (no web server or ports). Version: `15.1.0-cursor4`.
+
+### Rust toolchain
+
+- Requires **Rust 1.85+** (edition 2024). The VM's default Rust may be older; the update script handles installing the correct version.
+
+### System dependencies
+
+Tests for compressed-file searching require: `zsh`, `xz-utils`, `liblz4-tool`, `musl-tools`, `brotli`, `zstd`, `g++`. These are installed by the update script.
+
+### Key commands
+
+| Task | Command |
+|------|---------|
+| Build | `cargo build` |
+| Test | `cargo test --all` |
+| Lint | `cargo clippy --all` |
+| Run | `cargo run -- <args>` or `./target/debug/rg <args>` |
+
+### Notes
+
+- This is a pure Rust/Cargo workspace with 9 library crates under `crates/` and the binary at `crates/core/main.rs`.
+- `cargo clippy --all` produces ~64 style warnings (pre-existing); these are not errors.
+- The optional `pcre2` feature (`cargo build --features pcre2`) requires `libpcre2` C library; it is not needed for default builds.
+- Integration tests are at `tests/tests.rs`; unit tests are in each crate.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud-specific development instructions for this ripgrep fork.

### What's included

- Rust toolchain requirement (1.85+, edition 2024)
- System dependency list for full test coverage
- Key commands table (build, test, lint, run)
- Notes on workspace structure and pre-existing clippy warnings

### Verification

- `cargo build` - compiles all workspace crates successfully
- `cargo test --all` - 1,165+ tests pass, 0 failures
- `cargo clippy --all` - warnings only (pre-existing style suggestions)
- Built binary runs and produces correct search results
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="http://localhost:4000/agents/bc-dfc5522e-6963-4ea8-9c58-795f06e101c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="http://localhost:4000/background-agent?bcId=bc-dfc5522e-6963-4ea8-9c58-795f06e101c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

