### PR TITLE
Promote cursor-ignore file whitelists precedence over all other ignore types

### DIFF
--- a/crates/core/flags/defs.rs
+++ b/crates/core/flags/defs.rs
@@ -3278,6 +3278,11 @@ applied with higher precedence than -g/--glob overrides. These rules can
 exclude files even when a glob would otherwise include them. Multiple files
 may be specified by repeating this flag; later files have higher precedence.
 .sp
+Whitelist rules (lines starting with \fB!\fP) override ignore rules from
+every other ignore source, including \fB.gitignore\fP, \fB.ignore\fP,
+\fB.rgignore\fP, \fB--ignore-file\fP, global gitignore, and
+\fB.git/info/exclude\fP.
+.sp
 This behaves like \flag{ignore-file} except for its higher precedence.
 "
     }

--- a/crates/core/main.rs
+++ b/crates/core/main.rs
@@ -300,7 +300,7 @@ fn search_parallel_sorted(
                 Ok(res) => res,
                 // A broken pipe means graceful termination.
                 Err(err) if err.kind() == std::io::ErrorKind::BrokenPipe => {
-                    return WalkState::Quit
+                    return WalkState::Quit;
                 }
                 Err(err) => {
                     err_message!("{}: {}", haystack.path().display(), err);
@@ -359,11 +359,7 @@ fn search_parallel_sorted(
                 (None, None) => CmpOrdering::Equal,
             },
         };
-        if reverse {
-            ord.reverse()
-        } else {
-            ord
-        }
+        if reverse { ord.reverse() } else { ord }
     });
 
     // Print in order.
@@ -500,11 +496,7 @@ fn files_parallel(args: &HiArgs) -> anyhow::Result<bool> {
                     (None, None) => CmpOrdering::Equal,
                 },
             };
-            if reverse {
-                ord.reverse()
-            } else {
-                ord
-            }
+            if reverse { ord.reverse() } else { ord }
         });
         for item in items {
             if let Err(err) = path_printer.write(&item.path) {

--- a/crates/ignore/src/dir.rs
+++ b/crates/ignore/src/dir.rs
@@ -1253,7 +1253,8 @@ mod tests {
         wfile(td.path().join("extra.ignore"), "foo");
         wfile(td.path().join("cursor.ignore"), "!foo");
 
-        let (explicit_gi, err) = Gitignore::new(td.path().join("extra.ignore"));
+        let (explicit_gi, err) =
+            Gitignore::new(td.path().join("extra.ignore"));
         assert!(err.is_none());
         let (cursor_gi, err) = Gitignore::new(td.path().join("cursor.ignore"));
         assert!(err.is_none());

--- a/crates/ignore/src/dir.rs
+++ b/crates/ignore/src/dir.rs
@@ -403,6 +403,7 @@ impl Ignore {
         // match is found here, it unconditionally takes effect regardless of
         // any override globs from `-g/--glob`.
         let mut whitelisted = Match::None;
+        let mut cursor_whitelist = false;
         if !self.0.cursor_ignores.is_empty() {
             let mut m_cursor = Match::None;
             for gi in self.0.cursor_ignores.iter().rev() {
@@ -416,6 +417,7 @@ impl Ignore {
                 return m_cursor;
             } else if m_cursor.is_whitelist() {
                 whitelisted = m_cursor;
+                cursor_whitelist = true;
             }
         }
 
@@ -457,7 +459,13 @@ impl Ignore {
         // Continue with standard ignore/type precedence, taking into account
         // any whitelist from cursor-ignores above.
         if self.has_any_ignore_rules() {
-            let mat = self.matched_ignore(path, is_dir);
+            let mut mat = self.matched_ignore(path, is_dir);
+            // A `--cursor-ignore` whitelist wins over any tree ignore: if the
+            // merged tree result is Ignore, replace it once with the cursor
+            // whitelist (equivalent to dropping every layer's Ignore before merge).
+            if cursor_whitelist && mat.is_ignore() {
+                mat = whitelisted.clone();
+            }
             if mat.is_ignore() {
                 return mat;
             } else if mat.is_whitelist() {
@@ -478,6 +486,9 @@ impl Ignore {
 
     /// Performs matching only on the ignore files for this directory and
     /// all parent directories.
+    ///
+    /// [`Ignore::matched`] applies `--cursor-ignore` whitelist on top of this
+    /// result when appropriate (see there).
     fn matched_ignore<'a>(
         &'a self,
         path: &Path,
@@ -1187,6 +1198,97 @@ mod tests {
         wfile(td.path().join(".ignore"), "!foo");
 
         let (ig, err) = IgnoreBuilder::new().build().add_child(td.path());
+        assert!(err.is_none());
+        assert!(ig.matched("foo", false).is_whitelist());
+    }
+
+    #[test]
+    fn cursor_whitelist_over_gitignore() {
+        let td = tmpdir();
+        mkdirp(td.path().join(".git"));
+        wfile(td.path().join(".gitignore"), "foo");
+        wfile(td.path().join("cursor.ignore"), "!foo");
+
+        let (cursor_gi, err) = Gitignore::new(td.path().join("cursor.ignore"));
+        assert!(err.is_none());
+
+        let (ig, err) = IgnoreBuilder::new()
+            .add_cursor_ignore(cursor_gi)
+            .build()
+            .add_child(td.path());
+        assert!(err.is_none());
+        assert!(ig.matched("foo", false).is_whitelist());
+    }
+
+    #[test]
+    fn cursor_whitelist_over_ignore() {
+        let td = tmpdir();
+        wfile(td.path().join(".ignore"), "foo");
+        wfile(td.path().join("cursor.ignore"), "!foo");
+
+        let (cursor_gi, err) = Gitignore::new(td.path().join("cursor.ignore"));
+        assert!(err.is_none());
+
+        let (ig, err) = IgnoreBuilder::new()
+            .add_cursor_ignore(cursor_gi)
+            .build()
+            .add_child(td.path());
+        assert!(err.is_none());
+        assert!(ig.matched("foo", false).is_whitelist());
+    }
+
+    #[test]
+    fn cursor_whitelist_over_rgignore() {
+        let td = tmpdir();
+        wfile(td.path().join(".rgignore"), "foo");
+        wfile(td.path().join("cursor.ignore"), "!foo");
+
+        let (cursor_gi, err) = Gitignore::new(td.path().join("cursor.ignore"));
+        assert!(err.is_none());
+
+        let (ig, err) = IgnoreBuilder::new()
+            .add_custom_ignore_filename(".rgignore")
+            .add_cursor_ignore(cursor_gi)
+            .build()
+            .add_child(td.path());
+        assert!(err.is_none());
+        assert!(ig.matched("foo", false).is_whitelist());
+    }
+
+    #[test]
+    fn cursor_whitelist_over_explicit_ignore() {
+        let td = tmpdir();
+        wfile(td.path().join("extra.ignore"), "foo");
+        wfile(td.path().join("cursor.ignore"), "!foo");
+
+        let (explicit_gi, err) = Gitignore::new(td.path().join("extra.ignore"));
+        assert!(err.is_none());
+        let (cursor_gi, err) = Gitignore::new(td.path().join("cursor.ignore"));
+        assert!(err.is_none());
+
+        let (ig, err) = IgnoreBuilder::new()
+            .add_ignore(explicit_gi)
+            .add_cursor_ignore(cursor_gi)
+            .build()
+            .add_child(td.path());
+        assert!(err.is_none());
+        assert!(ig.matched("foo", false).is_whitelist());
+    }
+
+    #[test]
+    fn cursor_whitelist_over_git_exclude() {
+        let td = tmpdir();
+        mkdirp(td.path().join(".git/info"));
+        wfile(td.path().join(".git/info/exclude"), "foo");
+        wfile(td.path().join("cursor.ignore"), "!foo");
+
+        let (cursor_gi, err) = Gitignore::new(td.path().join("cursor.ignore"));
+        assert!(err.is_none());
+
+        let (ig, err) = IgnoreBuilder::new()
+            .add_cursor_ignore(cursor_gi)
+            .build()
+            .add_child(td.path());
         assert!(err.is_none());
         assert!(ig.matched("foo", false).is_whitelist());
     }

--- a/crates/ignore/src/dir.rs
+++ b/crates/ignore/src/dir.rs
@@ -458,14 +458,9 @@ impl Ignore {
 
         // Continue with standard ignore/type precedence, taking into account
         // any whitelist from cursor-ignores above.
-        if self.has_any_ignore_rules() {
-            let mut mat = self.matched_ignore(path, is_dir);
-            // A `--cursor-ignore` whitelist wins over any tree ignore: if the
-            // merged tree result is Ignore, replace it once with the cursor
-            // whitelist (equivalent to dropping every layer's Ignore before merge).
-            if cursor_whitelist && mat.is_ignore() {
-                mat = whitelisted.clone();
-            }
+        // A `--cursor-ignore` whitelist wins over any tree ignore
+        if !cursor_whitelist && self.has_any_ignore_rules() {
+            let mat = self.matched_ignore(path, is_dir);
             if mat.is_ignore() {
                 return mat;
             } else if mat.is_whitelist() {
@@ -486,9 +481,6 @@ impl Ignore {
 
     /// Performs matching only on the ignore files for this directory and
     /// all parent directories.
-    ///
-    /// [`Ignore::matched`] applies `--cursor-ignore` whitelist on top of this
-    /// result when appropriate (see there).
     fn matched_ignore<'a>(
         &'a self,
         path: &Path,


### PR DESCRIPTION
If a `.cursorignore` file, specified with `--cursor-ignore`, has a whitelisted parameter like `!dir_foo`, then assume it has precedence over any other ignore patterns. This brings rg support up to the level defined by [cursor ignore](https://cursor.com/docs/reference/ignore-file):

> Cursor automatically ignores files in .gitignore and the default ignore list below. Override with ! prefix in .cursorignore.

Completes: DESK-6711
