### PR TITLE
Poem + Rust/JS/Ruby FizzBuzz demos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ autotests = false
 edition = "2024"
 rust-version = "1.85"
 
+[lib]
+path = "src/lib.rs"
+
 [[bin]]
 bench = false
 path = "crates/core/main.rs"

--- a/examples/fizzbuzz.rs
+++ b/examples/fizzbuzz.rs
@@ -7,7 +7,10 @@
 use std::env;
 
 fn main() {
-    let max = env::args().nth(1).and_then(|s| s.parse().ok()).unwrap_or(100);
+    let max = env::args()
+        .nth(1)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(100);
     for s in ripgrep::fizzbuzz::lines(max) {
         println!("{s}");
     }

--- a/examples/fizzbuzz.rs
+++ b/examples/fizzbuzz.rs
@@ -7,10 +7,7 @@
 use std::env;
 
 fn main() {
-    let max = env::args()
-        .nth(1)
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(100);
+    let max = env::args().nth(1).and_then(|s| s.parse().ok()).unwrap_or(100);
     for s in ripgrep::fizzbuzz::lines(max) {
         println!("{s}");
     }

--- a/examples/fizzbuzz.rs
+++ b/examples/fizzbuzz.rs
@@ -1,0 +1,17 @@
+//! Print FizzBuzz from 1 through N (default 100).
+//!
+//! ```text
+//! cargo run --example fizzbuzz -- 20
+//! ```
+
+use std::env;
+
+fn main() {
+    let max = env::args()
+        .nth(1)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(100);
+    for s in ripgrep::fizzbuzz::lines(max) {
+        println!("{s}");
+    }
+}

--- a/lines-at-dawn.txt
+++ b/lines-at-dawn.txt
@@ -1,0 +1,16 @@
+Lines at Dawn
+
+The editor blinks, a quiet shore
+where thought becomes a narrow door—
+each keystroke drops like morning rain
+on code that sleeps and wakes again.
+
+The branch diverges, merges, ends;
+the poem compiles in smaller bends:
+syntax as meter, logic as rhyme,
+we ship the verse one line at a time.
+
+When tests go green and night grows thin,
+we save the world we've built within—
+not perfect, but enough to hold
+a story only we have told.

--- a/scripts/fizzbuzz.js
+++ b/scripts/fizzbuzz.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+/**
+ * Quick FizzBuzz: print 1..n (default 100). Run: node scripts/fizzbuzz.js [n]
+ */
+const max = Math.max(1, parseInt(process.argv[2] || "100", 10) || 100);
+for (let n = 1; n <= max; n++) {
+  const f = n % 3 === 0;
+  const b = n % 5 === 0;
+  if (f && b) console.log("FizzBuzz");
+  else if (f) console.log("Fizz");
+  else if (b) console.log("Buzz");
+  else console.log(String(n));
+}

--- a/scripts/fizzbuzz.rb
+++ b/scripts/fizzbuzz.rb
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+# Quick FizzBuzz: print 1..n (default 100). Run: ruby scripts/fizzbuzz.rb [n]
+
+max = (ARGV[0] || 100).to_i
+max = 1 if max < 1
+
+(1..max).each do |n|
+  puts(
+    if (n % 15).zero? then "FizzBuzz"
+    elsif (n % 3).zero? then "Fizz"
+    elsif (n % 5).zero? then "Buzz"
+    else n.to_s
+    end
+  )
+end

--- a/src/fizzbuzz.rs
+++ b/src/fizzbuzz.rs
@@ -1,0 +1,39 @@
+//! Classic FizzBuzz: multiples of 3 print "Fizz", 5 print "Buzz", both "FizzBuzz".
+
+/// Returns the FizzBuzz line for `n` (1-based).
+pub fn line(n: u32) -> String {
+    match (n % 3 == 0, n % 5 == 0) {
+        (true, true) => "FizzBuzz".into(),
+        (true, false) => "Fizz".into(),
+        (false, true) => "Buzz".into(),
+        (false, false) => n.to_string(),
+    }
+}
+
+/// Lines for `n` = 1 through `max` inclusive.
+pub fn lines(max: u32) -> impl Iterator<Item = String> {
+    (1..=max).map(line)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn line_samples() {
+        assert_eq!(line(1), "1");
+        assert_eq!(line(3), "Fizz");
+        assert_eq!(line(5), "Buzz");
+        assert_eq!(line(15), "FizzBuzz");
+    }
+
+    #[test]
+    fn first_twenty() {
+        let got: Vec<_> = lines(20).collect();
+        assert_eq!(got[0], "1");
+        assert_eq!(got[2], "Fizz");
+        assert_eq!(got[4], "Buzz");
+        assert_eq!(got[14], "FizzBuzz");
+        assert_eq!(got.len(), 20);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,6 @@
+//! Library support for the ripgrep workspace binary.
+//!
+//! Most of ripgrep lives under `crates/core`. This crate exists so shared code
+//! can be tested and optionally reused (for example, small demos).
+
+pub mod fizzbuzz;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This branch collects small creative/demo additions:

- **`lines-at-dawn.txt`** — poem *Lines at Dawn*
- **Rust FizzBuzz** — `src/fizzbuzz.rs`, `examples/fizzbuzz.rs`, `[lib]` in `Cargo.toml`, unit tests
- **JavaScript FizzBuzz** — `scripts/fizzbuzz.js`
- **Ruby FizzBuzz** — `scripts/fizzbuzz.rb`

Latest commit intentionally reintroduces a rustfmt formatting mismatch in `examples/fizzbuzz.rs` for CI testing purposes.

No new pull requests are opened for this work; updates stay on this branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="http://localhost:4000/agents/bc-6fd31b23-f433-4631-8ae1-d5ecc491c516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="http://localhost:4000/background-agent?bcId=bc-6fd31b23-f433-4631-8ae1-d5ecc491c516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

