### PR TITLE
Add FizzBuzz module, example, and tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ autotests = false
 edition = "2024"
 rust-version = "1.85"
 
+[lib]
+path = "src/lib.rs"
+
 [[bin]]
 bench = false
 path = "crates/core/main.rs"

--- a/examples/fizzbuzz.rs
+++ b/examples/fizzbuzz.rs
@@ -1,0 +1,17 @@
+//! Print FizzBuzz from 1 through N (default 100).
+//!
+//! ```text
+//! cargo run --example fizzbuzz -- 20
+//! ```
+
+use std::env;
+
+fn main() {
+    let max = env::args()
+        .nth(1)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(100);
+    for s in ripgrep::fizzbuzz::lines(max) {
+        println!("{s}");
+    }
+}

--- a/src/fizzbuzz.rs
+++ b/src/fizzbuzz.rs
@@ -1,0 +1,39 @@
+//! Classic FizzBuzz: multiples of 3 print "Fizz", 5 print "Buzz", both "FizzBuzz".
+
+/// Returns the FizzBuzz line for `n` (1-based).
+pub fn line(n: u32) -> String {
+    match (n % 3 == 0, n % 5 == 0) {
+        (true, true) => "FizzBuzz".into(),
+        (true, false) => "Fizz".into(),
+        (false, true) => "Buzz".into(),
+        (false, false) => n.to_string(),
+    }
+}
+
+/// Lines for `n` = 1 through `max` inclusive.
+pub fn lines(max: u32) -> impl Iterator<Item = String> {
+    (1..=max).map(line)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn line_samples() {
+        assert_eq!(line(1), "1");
+        assert_eq!(line(3), "Fizz");
+        assert_eq!(line(5), "Buzz");
+        assert_eq!(line(15), "FizzBuzz");
+    }
+
+    #[test]
+    fn first_twenty() {
+        let got: Vec<_> = lines(20).collect();
+        assert_eq!(got[0], "1");
+        assert_eq!(got[2], "Fizz");
+        assert_eq!(got[4], "Buzz");
+        assert_eq!(got[14], "FizzBuzz");
+        assert_eq!(got.len(), 20);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,6 @@
+//! Library support for the ripgrep workspace binary.
+//!
+//! Most of ripgrep lives under `crates/core`. This crate exists so shared code
+//! can be tested and optionally reused (for example, small demos).
+
+pub mod fizzbuzz;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a minimal `ripgrep` library target so FizzBuzz can live in-tree with tests:

- **`src/fizzbuzz.rs`** — `line(n)` and `lines(max)` iterators
- **`examples/fizzbuzz.rs`** — prints 1..N (default 100): `cargo run -p ripgrep --example fizzbuzz -- 20`
- **Unit tests** in the same module

`Cargo.toml` gains `[lib]` pointing at `src/lib.rs`. The existing `rg` binary is unchanged.

**Note:** The workspace uses `edition = "2024"` and `rust-version = "1.85"`; CI should use a toolchain that matches. Local verification used `cargo +stable test -p ripgrep --lib` after installing current stable.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="http://localhost:4000/agents/bc-6fd31b23-f433-4631-8ae1-d5ecc491c516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="http://localhost:4000/background-agent?bcId=bc-6fd31b23-f433-4631-8ae1-d5ecc491c516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

