### PR TITLE
chore(ci): intentional compile failure for CI smoke test

### DIFF
--- a/crates/grep/src/lib.rs
+++ b/crates/grep/src/lib.rs
@@ -12,6 +12,9 @@ are sparse.
 A cookbook and a guide are planned.
 */
 
+// Deliberate compile failure for CI feature testing. Delete this line before merging.
+compile_error!("CI smoke test: intentional failure (netto/ci-smoke-fail-5591)");
+
 pub extern crate grep_cli as cli;
 pub extern crate grep_matcher as matcher;
 #[cfg(feature = "pcre2")]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This draft PR adds a temporary `compile_error!` in `crates/grep/src/lib.rs` so the workspace build fails predictably. It is only for exercising CI failure handling.

**Do not merge.** Remove the `compile_error!` line before any real merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83c7ed5a-37f6-499b-b5c0-2df070c05591"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83c7ed5a-37f6-499b-b5c0-2df070c05591"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

